### PR TITLE
Adding dockerfile for racon 1.4.7

### DIFF
--- a/genomics/Dockerfile.racon_1.4.7
+++ b/genomics/Dockerfile.racon_1.4.7
@@ -1,0 +1,53 @@
+FROM ubuntu:19.04
+
+# docker build -f Dockerfile.racon_1.4.7 -t vanessa/racon:1.4.7 .
+# docker push vanessa/racon:1.4.7
+# singularity pull docker://vanessa/racon:1.4.7
+
+LABEL SOFTWARE_NAME Racon v1.4.7
+LABEL SOFTWARE_URL https://github.com/isovic/racon
+LABEL MAINTAINER "Tom Harrop"
+LABEL VERSION "Racon v1.4.7"
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y \
+        apt-transport-https \
+        build-essential \
+        cmake \
+        git \
+        language-pack-en \
+        lsb-release \
+        nvidia-modprobe \
+        python \
+        software-properties-common \
+        wget
+
+RUN add-apt-repository -y ppa:graphics-drivers/ppa && \
+    apt update && \
+    apt install -y \
+        nvidia-driver-430 \
+        nvidia-cuda-toolkit
+
+WORKDIR /racon
+RUN wget -O "racon.tar.gz" \
+        --no-check-certificate \
+        https://github.com/lbcb-sci/racon/releases/download/1.4.7/racon-v1.4.7.tar.gz
+RUN tar -zxf racon.tar.gz \
+        --strip-components 1 && \
+    rm racon.tar.gz
+
+# build and install with cuda support
+RUN git submodule update --init --recursive || true     # have to allow fail
+RUN mkdir build && cd build || exit 1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -Dracon_build_tests=ON \
+        -Dracon_build_wrapper=ON \
+        -D CUDA_TOOLKIT_ROOT_DIR=/usr/lib/cuda \
+        -Dracon_enable_cuda=ON \
+        .. && \
+    make && make install
+
+ENV PATH="${PATH}:/racon/build/bin"
+ENTRYPOINT ["/racon/build/bin/racon"]


### PR DESCRIPTION
Hey @TomHarrop ! This looks like a fairly large container, and I'm worried that you'll use up all your space in Sylabs Cloud really quickly! I know you aren't testing out Docker yet, but in case you wanted to try, I created a Dockerfile for your racon container, the Dockerfile presented here.  To build:

```bash
cd genomics
docker build -f Dockerfile.racon_1.4.7 -t vanessa/racon:1.4.7 .
```
Then (for example) here is how I pushed it to Docker Hub - you can do this for a quick test to pull with Singularity (but for production you'd want to have an automated build)

```bash
$ docker push vanessa/racon:1.4.7
```
And then to pull to Singularity:

```bash
$ singularity pull docker://vanessa/racon:1.4.7
```
The container above is a real thing! I've [pre-built](https://hub.docker.com/r/vanessa/racon) it for you so that you can try pulling to Singularity directly.

If you like this approach, I'd be glad to help set you up with doing Automated builds - my current recommendation is actually Quay.io because it allows for nice generation of permission specific tokens. Once you have a simple recipe, it's easy to copy pasta for more containers! :D 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>